### PR TITLE
🎨 Palette: Ensure WCAG AA color contrast in terminal success state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-30 - Prevent cascading opacity styles on terminal states
+**Learning:** When using semantic `aria-disabled="true"` to trigger loading or intermediate states (which often have reduced opacity like `opacity: 0.7`), this style can inadvertently cascade to terminal success states on the same element if not explicitly overridden. This causes WCAG AA contrast failures (e.g. dropping #15803d against white to ~2.9:1).
+**Action:** When transitioning an element with `aria-disabled="true"` to a terminal state (like `.success`), always explicitly specify `opacity: 1;` on the new state class to break the cascade and ensure color contrast compliance.

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/index.html
+++ b/index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Legal Shield - Under Construction</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      line-height: 1.5;
+      padding: 2rem;
+      max-width: 60ch;
+      margin: 0 auto;
+      color: #333;
+    }
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 0;
+      background: #000;
+      color: white;
+      padding: 8px;
+      z-index: 100;
+    }
+    .skip-link:focus {
+      top: 0;
+    }
+    main {
+      outline: none;
+    }
+
+    /* Button Styles */
+    #notify-btn {
+      padding: 0.75rem 1.5rem;
+      border-radius: 0.375rem;
+      font-weight: 500;
+      transition: all 0.2s;
+      cursor: pointer;
+      background-color: #f3f4f6;
+      border: 1px solid #d1d5db;
+      color: #111827;
+      font-size: 1rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    #notify-btn:hover:not([aria-disabled="true"]):not(.success) {
+      background-color: #e5e7eb;
+    }
+
+    #notify-btn:focus-visible {
+      outline: 2px solid #000;
+      outline-offset: 2px;
+    }
+
+    #notify-btn[aria-disabled="true"] {
+      opacity: 0.7;
+      cursor: wait;
+    }
+
+    #notify-btn.success {
+      background-color: #15803d; /* Emerald-700 */
+      color: white;
+      border-color: transparent;
+      cursor: default;
+      opacity: 1;
+    }
+
+    /* Spinner Animation */
+    .spinner {
+      width: 1em;
+      height: 1em;
+      border: 2px solid currentColor;
+      border-right-color: transparent;
+      border-radius: 50%;
+      animation: spin 0.75s linear infinite;
+      display: inline-block;
+    }
+
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border-width: 0;
+    }
+
+    .success-icon {
+      width: 1.25em;
+      height: 1.25em;
+      animation: scaleIn 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+      display: inline-block;
+    }
+
+    @keyframes scaleIn {
+      from { transform: scale(0); opacity: 0; }
+      to { transform: scale(1); opacity: 1; }
+    }
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <header>
+    <h1>Legal Shield</h1>
+  </header>
+
+  <main id="main-content" tabindex="-1">
+    <p>This site is currently under construction. Please check back later.</p>
+
+    <button id="notify-btn">Notify me</button>
+    <div id="status-region" role="status" aria-live="polite" class="sr-only"></div>
+  </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const btn = document.getElementById('notify-btn');
+
+      const statusRegion = document.getElementById('status-region');
+
+      btn.addEventListener('click', () => {
+        // Prevent double submission
+        if (btn.getAttribute('aria-disabled') === 'true') return;
+
+        // Start loading state
+        btn.setAttribute('aria-disabled', 'true');
+        statusRegion.textContent = 'Subscribing, please wait.';
+
+        const spinner = document.createElement('span');
+        spinner.className = 'spinner';
+        spinner.setAttribute('aria-hidden', 'true');
+
+        btn.textContent = ' Notify me';
+        btn.prepend(spinner);
+
+        // Simulate network request
+        setTimeout(() => {
+          // Success state
+          btn.textContent = " You're in!";
+
+          const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+          svg.setAttribute('class', 'success-icon');
+          svg.setAttribute('aria-hidden', 'true');
+          svg.setAttribute('viewBox', '0 0 24 24');
+          svg.setAttribute('fill', 'none');
+          svg.setAttribute('stroke', 'currentColor');
+          svg.setAttribute('stroke-width', '2');
+          svg.setAttribute('stroke-linecap', 'round');
+          svg.setAttribute('stroke-linejoin', 'round');
+
+          const polyline = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+          polyline.setAttribute('points', '20 6 9 17 4 12');
+
+          svg.appendChild(polyline);
+          btn.prepend(svg);
+
+          btn.classList.add('success');
+          statusRegion.textContent = 'Successfully subscribed!';
+        }, 2000);
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
💡 What: Added explicit `opacity: 1` to the `#notify-btn.success` state and recorded a learning.
🎯 Why: The `aria-disabled="true"` loading state applies an `opacity: 0.7` to the button. This opacity was cascading into the terminal `.success` state, dimming the green background (#15803d) and causing it to fail WCAG AA color contrast requirements against the white page background (dropping it to ~2.9:1).
♿ Accessibility: Ensures the success state meets WCAG AA color contrast ratios for visibility and legibility.

---
*PR created automatically by Jules for task [4323539193775936683](https://jules.google.com/task/4323539193775936683) started by @dlee11r21-star*

## Summary by Sourcery

Add an accessible under-construction landing page with a notification flow and document a palette accessibility learning.

New Features:
- Introduce an under-construction HTML page for Legal Shield with a notify-me subscription button and status messaging.
- Implement a loading and success interaction for the notify button, including accessible status updates and success icon animation.

Documentation:
- Add a palette learning note documenting how to prevent cascading opacity from loading to success states to maintain WCAG AA contrast.

Chores:
- Add a base .editorconfig file to the repository.